### PR TITLE
Feat/improvment dto returns

### DIFF
--- a/src/main/java/com/marley_store/stock_system/controller/user/UserController.java
+++ b/src/main/java/com/marley_store/stock_system/controller/user/UserController.java
@@ -1,11 +1,9 @@
 package com.marley_store.stock_system.controller.user;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.marley_store.stock_system.dto.user.CreateUserDTO;
-import com.marley_store.stock_system.dto.user.LoginUserDTO;
+import com.marley_store.stock_system.dto.restMessage.RestDataMessageDTO;
+import com.marley_store.stock_system.dto.user.*;
 import com.marley_store.stock_system.dto.jwtToken.RecoveryJwtTokenDTO;
-import com.marley_store.stock_system.dto.user.UpdatePasswordDTO;
-import com.marley_store.stock_system.dto.user.UpdateUserDTO;
 import com.marley_store.stock_system.dto.restMessage.RestMessageDTO;
 import com.marley_store.stock_system.model.user.*;
 import com.marley_store.stock_system.service.user.UserService;
@@ -31,8 +29,10 @@ public class UserController {
     }
 
     @GetMapping("/get")
-    public Optional<User> getUser(HttpServletRequest request){
-        return userService.findByEmail(request);
+    public ResponseEntity<RestDataMessageDTO<GetUserDTO>> getUser(HttpServletRequest request){
+        GetUserDTO user = userService.findByEmail(request);
+        RestDataMessageDTO<GetUserDTO> restUserDTO = new RestDataMessageDTO<>(HttpStatus.OK.value(), "User request succesfully", user);
+        return ResponseEntity.status(HttpStatus.OK).body(restUserDTO);
     }
 
     @PatchMapping("/update")
@@ -40,7 +40,6 @@ public class UserController {
         userService.updateUser(updateUserDTO, request);
         RestMessageDTO successMessage = new RestMessageDTO(HttpStatus.OK.value(), "User updated successfully!");
         return ResponseEntity.status(HttpStatus.OK).body(successMessage);
-        //return new ResponseEntity<>("User updated successfully!", HttpStatus.OK);
     }
 
     @PatchMapping("/update-password")

--- a/src/main/java/com/marley_store/stock_system/controller/user/UserController.java
+++ b/src/main/java/com/marley_store/stock_system/controller/user/UserController.java
@@ -57,9 +57,10 @@ public class UserController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<RecoveryJwtTokenDTO> authenticateUser(@RequestBody LoginUserDTO loginUserDto){
+    public ResponseEntity<RestDataMessageDTO<RecoveryJwtTokenDTO>> authenticateUser(@RequestBody LoginUserDTO loginUserDto){
         RecoveryJwtTokenDTO token = userService.authenticateUser(loginUserDto);
-        return new ResponseEntity<>(token, HttpStatus.OK);
+        RestDataMessageDTO<RecoveryJwtTokenDTO> successMessage = new RestDataMessageDTO(HttpStatus.OK.value(), "User logged succesfully", token);
+        return ResponseEntity.status(HttpStatus.OK).body(successMessage);
     }
 
     @GetMapping("/test")

--- a/src/main/java/com/marley_store/stock_system/controller/user/UserController.java
+++ b/src/main/java/com/marley_store/stock_system/controller/user/UserController.java
@@ -1,4 +1,4 @@
-package com.marley_store.stock_system.controller;
+package com.marley_store.stock_system.controller.user;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.marley_store.stock_system.dto.user.CreateUserDTO;

--- a/src/main/java/com/marley_store/stock_system/dto/user/GetUserDTO.java
+++ b/src/main/java/com/marley_store/stock_system/dto/user/GetUserDTO.java
@@ -1,0 +1,25 @@
+package com.marley_store.stock_system.dto.user;
+
+import com.marley_store.stock_system.dto.product.GetProductDTO;
+import com.marley_store.stock_system.model.role.Role;
+import com.marley_store.stock_system.model.user.User;
+
+import java.util.List;
+
+public record GetUserDTO(
+        Long id,
+        String name,
+        String email,
+        String cnpj,
+        List<Role> roles
+) {
+    public GetUserDTO(User user){
+        this(
+                user.getId(),
+                user.getName(),
+                user.getEmail(),
+                user.getCnpj(),
+                user.getRoles()
+        );
+    }
+}

--- a/src/main/java/com/marley_store/stock_system/service/user/UserService.java
+++ b/src/main/java/com/marley_store/stock_system/service/user/UserService.java
@@ -7,11 +7,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marley_store.stock_system.config.security.SecurityConfiguration;
 import com.marley_store.stock_system.config.userAuthenticationFilter.UserAuthenticationFilter;
-import com.marley_store.stock_system.dto.user.CreateUserDTO;
-import com.marley_store.stock_system.dto.user.LoginUserDTO;
+import com.marley_store.stock_system.dto.user.*;
 import com.marley_store.stock_system.dto.jwtToken.RecoveryJwtTokenDTO;
-import com.marley_store.stock_system.dto.user.UpdatePasswordDTO;
-import com.marley_store.stock_system.dto.user.UpdateUserDTO;
 import com.marley_store.stock_system.exceptions.jwtToken.TokenGenerationFailed;
 import com.marley_store.stock_system.exceptions.user.UserNotFoundException;
 import com.marley_store.stock_system.model.role.Role;
@@ -55,9 +52,13 @@ public class UserService {
     private UserAuthenticationFilter userAuthenticationFilter;
 
 
-    public Optional<User> findByEmail(HttpServletRequest request){
+    public GetUserDTO findByEmail(HttpServletRequest request){
         String email = userAuthenticationFilter.getEmailToken(request);
-        return userRepository.findByEmail(email);
+        Optional<User> user = userRepository.findByEmail(email);
+
+        if(!user.isPresent()) throw new UserNotFoundException();
+
+        return new GetUserDTO(user.get());
     }
 
     public List<User> getAllUsers(){


### PR DESCRIPTION
Task:
We have two entities implemented today: User and Products.
These entities do not have a correct standardization for returns, such as user returning the complete user, with sensitive user data, such as email and password (encrypted).
The idea is that we add DTOs to all the returns we have today, with an effective standardization.

What we made:

Then, the user controller was using the model user to return on "/get" endpoint, the "/login" endpoint returned just token object, and now they return DTOs 